### PR TITLE
Add adjustable token/temperature settings and chat UX polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# simple-chatbot
+# Simple Chatbot
+
+This project provides a minimal web based chat client for talking to
+models hosted on [OpenRouter](https://openrouter.ai/).  A small Python
+proxy is included to work around browser CORS restrictions.
+
+## Running locally
+
+1. Install dependencies:
+
+   ```bash
+   pip install requests
+   ```
+
+2. Start the local proxy server:
+
+   ```bash
+   python run_server.py
+   ```
+
+   The application will be available at `http://localhost:8000`.
+
+3. Open `chat.html` in your browser and enter your OpenRouter API key in
+   the **Settings** dialog.
+
+## Features
+
+* Conversation history stored in `localStorage`.
+* Adjustable model, system prompt, context length, **max tokens**, and
+  **temperature** settings.
+* `Shift+Enter` inserts a new line while `Enter` sends the message.
+* Code blocks can be copied or downloaded directly from the chat.
+
+## License
+
+MIT
+

--- a/chat.html
+++ b/chat.html
@@ -45,7 +45,7 @@
         </div>
         <div class="chat-footer">
             <div class="chat-input">
-                <textarea id="user-input" placeholder="Type your message..." rows="1" autocomplete="off"></textarea>
+                <textarea id="user-input" placeholder="Type your message... (Shift+Enter for newline)" rows="1" autocomplete="off"></textarea>
                 <button type="button" class="input-button" id="send-btn" aria-label="Send message">
                     <i class="fas fa-paper-plane"></i>
                 </button>


### PR DESCRIPTION
## Summary
- Add persistent max token and temperature settings
- Allow Shift+Enter for multiline input and auto-expand textarea
- Document setup and features in README

## Testing
- `node --check script.js`
- `python -m py_compile run_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7c9442e28832a95fec39884b664a7